### PR TITLE
Changed slash to backslash for lang files (compatibility)

### DIFF
--- a/Downtify/Downtify.csproj
+++ b/Downtify/Downtify.csproj
@@ -171,12 +171,12 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="language/en.xml">
+    <None Include="language\en.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="language/de.xml">
+    <None Include="language\de.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Downtify/GUI/frmMain.cs
+++ b/Downtify/GUI/frmMain.cs
@@ -212,10 +212,16 @@ namespace Downtify.GUI
             downloader.Download(((TrackItem)listBoxTracks.SelectedItems[0]).Track);
         }
 
-        private string BuildSpotifyURI(string link)
+        private string BuildSpotifyURI(string url)
         {
-            string[] splitter = link.Substring(8, link.Length-8).Split('/');
-            return "spotify:" + splitter[1] + ":" + splitter[2];
+            url = url.Replace("https://", "");
+            url = url.Replace("http://", "");
+            url = url.Replace("www", "");
+            url = url.Replace("play.", "");
+            url = url.Replace(".com", "");
+            url = url.Replace("/", ":");
+
+            return url;
         }
     }
 }


### PR DESCRIPTION
On VS 2013 you can't open lang files in code editor
Bei VS2013 lassen sich die Sprachdateien im Code-Editor nicht öffnen, wegen dem "falschen" Slash
