### PR TITLE
More flexible way for BuildSpotifyURI and slash changed to backslash in csproj file

### DIFF
--- a/Downtify/Downtify.csproj
+++ b/Downtify/Downtify.csproj
@@ -171,12 +171,12 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="language/en.xml">
+    <None Include="language\en.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="language/de.xml">
+    <None Include="language\de.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Downtify/GUI/frmMain.cs
+++ b/Downtify/GUI/frmMain.cs
@@ -212,10 +212,16 @@ namespace Downtify.GUI
             downloader.Download(((TrackItem)listBoxTracks.SelectedItems[0]).Track);
         }
 
-        private string BuildSpotifyURI(string link)
+        private string BuildSpotifyURI(string url)
         {
-            string[] splitter = link.Substring(8, link.Length-8).Split('/');
-            return "spotify:" + splitter[1] + ":" + splitter[2];
+            url = url.Replace("https://", "");
+            url = url.Replace("http://", "");
+            url = url.Replace("www", "");
+            url = url.Replace("play.", "");
+            url = url.Replace(".com", "");
+            url = url.Replace("/", ":");
+
+            return url;
         }
     }
 }

--- a/Downtify/GUI/frmMain.cs
+++ b/Downtify/GUI/frmMain.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Windows.Forms;
 using System.Drawing;
+using System.Text.RegularExpressions;
 
 namespace Downtify.GUI
 {
@@ -214,14 +215,22 @@ namespace Downtify.GUI
 
         private string BuildSpotifyURI(string url)
         {
-            url = url.Replace("https://", "");
-            url = url.Replace("http://", "");
-            url = url.Replace("www", "");
-            url = url.Replace("play.", "");
-            url = url.Replace(".com", "");
-            url = url.Replace("/", ":");
+            string uri = url;
 
-            return url;
+            Regex regex = new Regex(@".+(?<user>user)\/(?<uid>.+)\/(?<type>playlist|album|track)\/(?<tid>.+)");
+
+            Match match = regex.Match(url);
+
+            if(match.Success)
+            {
+                string user = match.Groups["user"].Value;
+                string uid = match.Groups["uid"].Value;
+                string type = match.Groups["type"].Value;
+                string tid = match.Groups["tid"].Value;
+
+                uri = "spotify:" + user + ":" + uid + ":" + type + ":" + tid;
+            }
+            return uri;
         }
     }
 }


### PR DESCRIPTION
Slash to backslash, because VS2013 can't handle slash. So you can't open lang files.

BuildSpotifyURI
I think its more flexible. In future maybe with regex
